### PR TITLE
add critical database indexes for chart aggregation queries

### DIFF
--- a/scripts/createIndexes.cjs
+++ b/scripts/createIndexes.cjs
@@ -35,6 +35,23 @@ async function createIndexes() {
     await visitorsCollection.createIndex({ valid: 1 });
     await visitorsCollection.createIndex({ valid: 1, realMode: 1 });
     await visitorsCollection.createIndex({ hasStarted: 1 });
+    
+    // Indexes for chart data aggregation queries (getVisitorDocuments function)
+    // These are critical for performance when filtering games for chart display
+    await visitorsCollection.createIndex({ 
+      durationOfGame: 1, 
+      realMode: 1, 
+      buys: 1, 
+      sells: 1 
+    });
+    await visitorsCollection.createIndex({ 
+      durationOfGame: 1, 
+      buys: 1, 
+      sells: 1, 
+      portfolioCAGR: 1, 
+      buyHoldCAGR: 1 
+    });
+    
     console.log('✓ Created indexes on visitors collection');
 
     console.log('\nAll indexes created successfully!');


### PR DESCRIPTION
- add compound index on durationofgame, realmode, buys, sells for real mode queries
- add compound index on durationofgame, buys, sells, portfoliocagr, buyholdcagr for simulated mode
- these indexes prevent full collection scans that were causing 502 timeouts
- aggregation queries should now execute in milliseconds instead of timing out